### PR TITLE
 refactor: use cosmiconfig v5, remove mock-require

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ must install it and specify its use by using the `--require` CLI flag._
 
 Returns a `Promise`, which resolves with an `Object` containing:
 
-#### `allowZero`
+#### `allowMissing`
 
 Type: `Boolean`  
 Default: `false`

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,19 +1,36 @@
 const chalk = require('chalk');
-const mock = require('mock-require');
+const cosmiconfig = require('cosmiconfig');
 const resolvePath = require('resolve').sync;
 const webpackLog = require('webpack-log');
 
 const LoadConfigError = require('./LoadConfigError');
 const RequireModuleError = require('./RequireModuleError');
 
+const cwd = process.cwd();
+const { loadJs } = cosmiconfig;
+const prefix = 'webpack';
+const cosmicOptions = {
+  loaders: {
+    '.es6': loadJs,
+    '.flow': loadJs,
+    '.mjs': loadJs,
+    '.ts': loadJs,
+  },
+  searchPlaces: [
+    `${prefix}.config.js`,
+    `${prefix}.config.es6`,
+    `${prefix}.config.flow`,
+    `${prefix}.config.mjs`,
+    `${prefix}.config.ts`,
+    `.${prefix}rc`,
+    'package.json',
+    `.${prefix}rc.json`,
+    `.${prefix}rc.yaml`,
+    `.${prefix}rc.yml`,
+  ],
+};
+
 module.exports = (options = {}) => {
-  const altExtensions = [null, '.es6', '.flow', '.mjs', '.ts'];
-  const cosmicOptions = {
-    rcExtensions: true,
-    sync: true,
-  };
-  const configPrefix = 'webpack';
-  const cwd = process.cwd();
   const log = webpackLog({ name: 'config', id: 'webpack-config-loader' });
   const requires = [].concat(options.require).filter((r) => !!r);
 
@@ -40,52 +57,34 @@ module.exports = (options = {}) => {
     }
   }
 
-  mock('require-from-string', (...args) => {
-    const [, path] = args;
-    const resolved = resolvePath(path, { basedir: cwd });
-
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    return require(resolved);
-  });
-
-  // ensures that cosmiconfig is using our mock
-  const cosmiconfig = mock.reRequire('cosmiconfig');
   let config = {};
-  let configPath = '';
+  let { configPath } = options;
 
-  for (const extension of altExtensions) {
-    let js = `${configPrefix}.config.js`;
+  const explorer = cosmiconfig(prefix, cosmicOptions);
 
-    if (extension) {
-      js = `${configPrefix}.config${extension}`;
-      log.debug(chalk`Config not found, trying {grey ${js}}`);
+  try {
+    let result;
+    if (configPath) {
+      result = explorer.loadSync(configPath) || {};
+    } else {
+      result = explorer.searchSync(options.cwd) || {};
     }
 
-    const opts = Object.assign({}, cosmicOptions, { js });
+    ({ config, filepath: configPath } = result);
 
-    if (options.configPath) {
-      opts.configPath = options.configPath;
+    log.debug(chalk`Found config at {grey ${configPath}}`);
+  } catch (e) {
+    if (configPath) {
+      log.error(chalk`An error ocurred while trying to load {grey ${configPath}}
+              Did you forget to specify a --require?`);
+    } else {
+      log.error(chalk`An error ocurred while trying to find a config file
+              Did you forget to specify a --require?`);
     }
-
-    const explorer = cosmiconfig(configPrefix, opts);
-
-    try {
-      ({ config, filepath: configPath } = explorer.load(options.cwd) || {});
-    } catch (e) {
-      // prettier-ignore
-      log.error(chalk`An error ocurred while trying to load: {grey ${configPath || js}}
-            Did you forget to specify a --require?`);
-      throw new LoadConfigError(e, configPath);
-    }
-
-    if (config) {
-      break;
-    }
+    throw new LoadConfigError(e, configPath);
   }
 
-  mock.stop('require-from-string');
-
-  if (!configPath && !options.allowZero) {
+  if (!configPath && !options.allowMissing) {
     // prettier-ignore
     log.error(chalk`Unable to load a config from: {grey ${options.cwd}}`);
     const e = new Error(`Unable to load a config from: ${options.cwd}`);
@@ -95,7 +94,5 @@ module.exports = (options = {}) => {
     configPath = configPath || '';
   }
 
-  const result = { config, configPath };
-
-  return result;
+  return { config, configPath };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,20 @@
         "lodash.pick": "4.4.0",
         "lodash.topairs": "4.3.0",
         "resolve-from": "4.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
+          }
+        }
       }
     },
     "@commitlint/message": {
@@ -2487,14 +2501,13 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.2.tgz",
+      "integrity": "sha512-zJV4MeVVN4DN/RdvqJURLFBnIfdwJDSHJ9IoxxqwnW48ZNKG9rbOEZb5tuWpnjLkqKCYvDKqGFt7egAUFHdakQ==",
       "requires": {
         "is-directory": "0.3.1",
         "js-yaml": "3.11.0",
-        "parse-json": "4.0.0",
-        "require-from-string": "2.0.2"
+        "parse-json": "4.0.0"
       }
     },
     "create-ecdh": {
@@ -4769,7 +4782,8 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
@@ -6285,6 +6299,18 @@
             }
           }
         },
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -7533,15 +7559,6 @@
         }
       }
     },
-    "mock-require": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.2.tgz",
-      "integrity": "sha512-aD/Y1ZFHqw5pHg3HVQ50dLbfaAAcytS6sqLuhP51Dk3TSPdFb2VkSAa3mjrHifLIlGAtwQHJHINafAyqAne7vA==",
-      "requires": {
-        "get-caller-file": "1.0.2",
-        "normalize-path": "2.1.1"
-      }
-    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -7732,6 +7749,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
@@ -12054,7 +12072,8 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -12136,7 +12155,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,8 @@
   },
   "dependencies": {
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
-    "cosmiconfig": "^4.0.0",
+    "cosmiconfig": "^5.0.2",
     "loud-rejection": "^1.6.0",
-    "mock-require": "^3.0.2",
     "resolve": "^1.6.0",
     "webpack-log": "^1.1.2"
   },

--- a/test/fixtures/failures/bad-file/webpack.config.js
+++ b/test/fixtures/failures/bad-file/webpack.config.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-lines
+bad();
+
+module.exports = {
+  mode: 'common-js',
+};

--- a/test/test.js
+++ b/test/test.js
@@ -7,3 +7,4 @@ require('./snapshot');
 require('./tests/load');
 require('./tests/resolve');
 require('./tests/full');
+require('./tests/errors');

--- a/test/tests/errors.js
+++ b/test/tests/errors.js
@@ -1,0 +1,13 @@
+const RequireModuleError = require('../../lib/RequireModuleError');
+
+describe('RequireModuleError', () => {
+  it(`should construct an error`, () => {
+    const base = new Error('message');
+    const error = new RequireModuleError(base, 'test');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('RequireModuleError');
+    expect(error.stack).toContain('errors.js');
+    expect(error.meta.moduleName).toBe('test');
+  });
+});

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -49,7 +49,7 @@ describe('Load', () => {
 
   it('should not throw for config not found, but allowed', () => {
     const result = load({
-      allowZero: true,
+      allowMissing: true,
       cwd: `./test/fixtures/formats/not-found`,
     });
 

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -1,3 +1,5 @@
+const { resolve } = require('path');
+
 const webpackLog = require('webpack-log');
 
 const formats = {
@@ -54,5 +56,28 @@ describe('Load', () => {
     });
 
     expect(result).toMatchSnapshot();
+  });
+
+  it('should throw error for a bad config', () => {
+    const failure = () => {
+      load({}, { cwd: `./test/fixtures/failures/bad-config` });
+    };
+
+    expect(failure).toThrow();
+  });
+
+  it('should throw error for a bad exact config', () => {
+    const failure = () => {
+      load(
+        {},
+        {
+          configPath: resolve(
+            `./test/fixtures/failures/bad-config/webpack.config.js`
+          ),
+        }
+      );
+    };
+
+    expect(failure).toThrow();
   });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When using Cosmiconfig@4 we had to use some trickery with `mock-require` that had a lot of potholes. The awesome folks maintaining cosmiconfig have released v5 which doesn't require any require trickery to use require hooks (whew).

### Breaking Changes

The `allowZero` option renamed to `allowMissing`, as it makes more sense.

### Additional Info
