### PR TITLE
feat: add option to extend webpack schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ An object containing a valid
 [JSON Schema Definition](http://json-schema.org/latest/json-schema-validation.html).
 
 By default, `config-loader` validates your webpack config against the
-[webpack config schema](). However, it can be useful to append additional schema
-data to allow configs, which contain properties not present in the webpack schema,
-to pass validation.
+[webpack config schema](https://github.com/webpack/webpack/blob/master/schemas/WebpackOptions.json).
+However, it can be useful to append additional schema data to allow configs,
+which contain properties not present in the webpack schema, to pass validation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ See
 [Supported Compilers](https://github.com/webpack-contrib/config-loader#supported-compilers)
 for more information.
 
+### `schema`
+
+Type: `Object`
+Default: `undefined`
+
+An object containing a valid
+[JSON Schema Definition](http://json-schema.org/latest/json-schema-validation.html).
+
+By default, `config-loader` validates your webpack config against the
+[webpack config schema](). However, it can be useful to append additional schema
+data to allow configs, which contain properties not present in the webpack schema,
+to pass validation.
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const webpackLog = require('webpack-log');
 const validate = require('@webpack-contrib/schema-utils');
-const schema = require('webpack/schemas/WebpackOptions.json');
+const webpackSchema = require('webpack/schemas/WebpackOptions.json');
 
 const load = require('./load');
 const resolve = require('./resolve');
@@ -12,6 +12,7 @@ module.exports = (options = {}) => {
   const raw = load(options);
 
   return resolve(raw).then((result) => {
+    const schema = Object.assign({}, options.schema, webpackSchema);
     for (const target of [].concat(result.config)) {
       validate({ name, schema, target });
     }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -79,6 +79,17 @@ Object {
 }
 `;
 
+exports[`Load > should load with schema option #0 1`] = `
+Object {
+  "config": Object {
+    "entry": "object",
+    "mode": "development",
+    "serve": Object {},
+  },
+  "configPath": "<PROJECT_ROOT>/test/fixtures/types/schema/webpack.config.js",
+}
+`;
+
 exports[`Load > should not throw for config not found, but allowed #0 1`] = `
 Object {
   "config": Object {},

--- a/test/fixtures/types/schema/webpack.config.js
+++ b/test/fixtures/types/schema/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  entry: 'object',
+  mode: 'development',
+  serve: {}
+};

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -80,4 +80,20 @@ describe('Load', () => {
 
     expect(failure).toThrow();
   });
+
+  it(`should load with schema option`, () => {
+    const result = load({
+      schema: {
+        definitions: {
+          serve: {
+            additionalProperties: true,
+            type: 'object',
+          },
+        },
+      },
+      cwd: `./test/fixtures/types/schema`,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Consumers of `config-loader` may need the ability to validate custom properties in a `webpack.config.js` file, for which they will clean up before sending onto `webpack`. For example, `webpack-serve`'s custom `serve` property. This is not intended to be a widely consumed option, and will only be allowed if a direct consumer of this module chooses to utilize it.

### Breaking Changes

None

### Additional Info
