### PR TITLE
Fixing spelling of occurred in error messages

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -52,7 +52,7 @@ module.exports = (options = {}) => {
         require(modulePath);
       }
     } catch (e) {
-      log.error(chalk`An error ocurred while requiring: {grey ${module}}`);
+      log.error(chalk`An error occurred while requiring: {grey ${module}}`);
       throw new RequireModuleError(e, module);
     }
   }
@@ -75,10 +75,10 @@ module.exports = (options = {}) => {
     log.debug(chalk`Found config at {grey ${configPath}}`);
   } catch (e) {
     if (configPath) {
-      log.error(chalk`An error ocurred while trying to load {grey ${configPath}}
+      log.error(chalk`An error occurred while trying to load {grey ${configPath}}
               Did you forget to specify a --require?`);
     } else {
-      log.error(chalk`An error ocurred while trying to find a config file
+      log.error(chalk`An error occurred while trying to find a config file
               Did you forget to specify a --require?`);
     }
     throw new LoadConfigError(e, configPath);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Misspellings are very very slightly jarring to me (and maybe other users) so I think correcting the spelling of occurred is a very very slight improvement to this software.

### Additional Info

Forgot to add scope to the commit message -- sorry!